### PR TITLE
validator.js并没有直接依赖Widget，去掉该文件中的Widget依赖！

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -1,6 +1,5 @@
 define(function (require, exports, module) {
   var Core = require('./core'),
-      Widget = require('widget'),
       $ = require('$');
 
   var Validator = Core.extend({


### PR DESCRIPTION
validator.js并没有直接依赖Widget，去掉该文件中的Widget依赖！
